### PR TITLE
fix "Edit me" button URLs.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       gemoji (~> 2.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0)
-    json (1.8.3)
+    json (1.8.6)
     kramdown (1.11.1)
     liquid (3.0.6)
     listen (3.0.6)

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+repository: cloudmaven/documentation
 
 output: web
 # this property is useful for conditional filtering of content that is separate from the PDF.
@@ -11,7 +12,7 @@ site_title: Research Computing Resources
 company_name: cloudmaven
 # this appears in the footer
 
-github_editme_path: tomjohnson1492/documentation-theme-jekyll/blob/gh-pages/pages/
+github_editme_path: cloudmaven/documentation/blob/gh-pages/
 # if you're using Github, provide the basepath to the branch you've created for reviews, following the sample here. if not, leave this value blank.
 
 disqus_shortname: 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -42,7 +42,8 @@ layout: default
 
     {% if site.github_editme_path %}
 
-    <a target="_blank" href="https://github.com/{{site.github_editme_path}}/_pages/{{page.folder}}/{{page.url | remove: "/" | append: ".md"}}" class="btn btn-default githubEditButton" role="button"><i class="fa fa-github fa-lg"></i> Edit me</a>
+    <a target="_blank" href="https://github.com/{{site.github_editme_path}}{% unless page.url contains "index.html" %}pages/{% endunless %}{{page.folder}}{{page.url | remove: ".html" | append: ".md"}}" class="btn btn-default githubEditButton" role="button"><i class="fa fa-github fa-lg"></i> Edit me</a>
+
     {% endif %}
 
     {% endunless %}


### PR DESCRIPTION
Note: I did not include the `_site` directory changes, since I figure you'd want to rebuild yourself. I can include those changes if you desire. I wasn't sure about the image URLs, specifically, since they weren't rendering when I tested locally.

The configuration needed to point to the cloudmaven repository for the
"Edit me" buttons to work properly. Also, for the markdown files to link
correctly, I needed to update the github_editme_path portion of
page.html to match the latest version from the theme:
https://github.com/tomjohnson1492/documentation-theme-jekyll/blob/e4ed2d864d4c2a28ae232ba7a6c9485feed234ae/_layouts/page.html

Also, update the version of JSON used in Gemfile.lock.  I was getting
compilation errors when trying to test changes locally with `bundle exec
jekyll serve` per the instructions at
https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/